### PR TITLE
A few accessibility improvements for the GLKTextBuffer.

### DIFF
--- a/app/src/main/java/com/luxlunae/glk/view/window/GLKTextBufferV.java
+++ b/app/src/main/java/com/luxlunae/glk/view/window/GLKTextBufferV.java
@@ -157,8 +157,10 @@ public class GLKTextBufferV extends GLKTextWindowV implements HVScrollView.Scrol
         if (key == GLKConstants.keycode_Delete) {
             // BACKSPACE: Delete the character to the left of the cursor
             if (len > 0) {
+				String message = ""+mModel.mInput.toString().charAt(len-1)+" deleted";
                 mModel.mInput.setLength(--len);
-            }
+				announceForAccessibility(message);
+			}
         } else if (super.isTerminator(key)) {
             // Terminate the current input
             // Flush the contents of the string builder back out to the byte buffer
@@ -302,7 +304,7 @@ public class GLKTextBufferV extends GLKTextWindowV implements HVScrollView.Scrol
 
                 // Also ensure we announce this to users that have accessibility enabled
                 // (e.g. Google TalkBack)
-                //setContentDescription("text buffer " + mModel.getStreamId() + ": " + utterance);
+                setContentDescription(mLastFlush);
                 announceForAccessibility(mLastFlush);
             }
         }


### PR DESCRIPTION
Added an accessibility content description for the GLKTextBuffer. This means that Talkback can now review the contents of the view by character or word. The view is also now readable in Braille with Google BrailleBack.

Added an accessibility announcement on the GLKTextView for deleted characters when composing input.